### PR TITLE
Kubernetes controllers

### DIFF
--- a/kubernetes-controllers/README.md
+++ b/kubernetes-controllers/README.md
@@ -1,0 +1,28 @@
+# Выполнено ДЗ №
+
+ - [x] Основное ДЗ
+ - [x] Задание со *
+
+## В процессе сделано:
+ - Ответ на вопрос: Почему обновление ReplicaSet не повлекло обновление запущенных pod?
+В ReplicaSet не предусмотрено использование rolling update, поэтому обновления подов не произошло.
+ - Создан ReplicaSet сервиса frontend. Изменено количество реплик до 3 двумя способами: командой kubectl scale replicaset, а затем редактированием манифеста. 
+ - Собрана новая версия микросервиса frontend, после чего эта версия была применена в манифесте ReplicaSet. После применения обновленного манифеста выяснила, что ReplicaSet не производит обновления текущих работающих подов. 
+ - Собрано два image микросервиса paymentservice. Созданы манифесты ReplicaSet и Deployment для paymentservice. 
+ - Выяснила, что при применении обновленного Deployment применяется стратегия обновления Rolling Update, которая заменяет поды со старой версией на поды с новой версией. 
+ - Написано два манифеста Deployment с реализацией сценариев развертывания blue-green и Rolling Update
+ - Для микросервиса frontend создан Deployment с readinessProbe. Узнала, что после применения обновленного манифеста Deployment не будет пытаться продолжить обновление, пока readinessProbe для нового пода не станет успешной.
+ - Создан и применен манифест node-exporter-daemonset.yaml для развертывания DaemonSet с Node Exporter. На локалхост проброшен порт 9100 из пода node-exporter, после чего по url localhost:9100/metrics стали доступны метрики. 
+ - DaemonSet node-exporter-daemonset.yaml модернизирован таким образом, чтобы Node Exporter был развернут не только на worker, так и на master (control-plane) ноде.
+
+## Как запустить проект:
+```
+ - kubectl apply -f node-exporter-daemonset.yaml 
+ - kubectl port-forward node-exporter-*** 9100:9100
+```
+
+## Как проверить работоспособность:
+ - Перейти по ссылке localhost:9100/metrics 
+
+## PR checklist:
+ - [x] Выставлен label с темой домашнего задания

--- a/kubernetes-controllers/frontend-deployment.yaml
+++ b/kubernetes-controllers/frontend-deployment.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+  labels:
+    app: frontend
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: frontend
+  template:
+    metadata:
+      labels:
+        app: frontend
+    spec:
+      containers:
+      - name: server
+        image: anmcqueen/mcqueen_repo:frontend.v0.0.2
+        readinessProbe:
+          initialDelaySeconds: 10
+          httpGet:
+            path: "/_healthz"
+            port: 8080
+            httpHeaders:
+            - name: "Cookie"
+              value: "shop_session-id=x-readiness-probe"
+        env:
+        - name: PRODUCT_CATALOG_SERVICE_ADDR
+          value: "productcatalogservice:3550"
+        - name: CURRENCY_SERVICE_ADDR
+          value: "currencyservice:7000"
+        - name: CART_SERVICE_ADDR
+          value: "cartservice:7070"
+        - name: RECOMMENDATION_SERVICE_ADDR
+          value: "recommendationservice:8080"
+        - name: SHIPPING_SERVICE_ADDR
+          value: "shippingservice:50051"
+        - name: CHECKOUT_SERVICE_ADDR
+          value: "checkoutservice:5050"
+        - name: AD_SERVICE_ADDR
+          value: "adservice:9555"
+        - name: ENABLE_PROFILER
+          value: "0"

--- a/kubernetes-controllers/frontend-replicaset.yaml
+++ b/kubernetes-controllers/frontend-replicaset.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  name: frontend
+  labels:
+    app: frontend
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: frontend
+  template:
+    metadata:
+      labels:
+        app: frontend
+    spec:
+      containers:
+      - name: server
+        image: anmcqueen/mcqueen_repo:frontend.v0.0.2
+        env:
+        - name: PRODUCT_CATALOG_SERVICE_ADDR
+          value: "productcatalogservice:3550"
+        - name: CURRENCY_SERVICE_ADDR
+          value: "currencyservice:7000"
+        - name: CART_SERVICE_ADDR
+          value: "cartservice:7070"
+        - name: RECOMMENDATION_SERVICE_ADDR
+          value: "recommendationservice:8080"
+        - name: SHIPPING_SERVICE_ADDR
+          value: "shippingservice:50051"
+        - name: CHECKOUT_SERVICE_ADDR
+          value: "checkoutservice:5050"
+        - name: AD_SERVICE_ADDR
+          value: "adservice:9555"
+        - name: ENABLE_PROFILER
+          value: "0"

--- a/kubernetes-controllers/node-exporter-daemonset.yaml
+++ b/kubernetes-controllers/node-exporter-daemonset.yaml
@@ -1,0 +1,57 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app.kubernetes.io/component: exporter
+    app.kubernetes.io/name: node-exporter
+  name: node-exporter
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: exporter
+      app.kubernetes.io/name: node-exporter
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: exporter
+        app.kubernetes.io/name: node-exporter
+    spec:
+      containers:
+      - args:
+        - --path.sysfs=/host/sys
+        - --path.rootfs=/host/root
+        - --no-collector.wifi
+        - --no-collector.hwmon
+        - --collector.filesystem.ignored-mount-points=^/(dev|proc|sys|var/lib/docker/.+|var/lib/kubelet/pods/.+)($|/)
+        - --collector.netclass.ignored-devices=^(veth.*)$
+        name: node-exporter
+        image: prom/node-exporter
+        ports:
+          - containerPort: 9100
+            protocol: TCP
+        resources:
+          limits:
+            cpu: 250m
+            memory: 180Mi
+          requests:
+            cpu: 102m
+            memory: 180Mi
+        volumeMounts:
+        - mountPath: /host/sys
+          mountPropagation: HostToContainer
+          name: sys
+          readOnly: true
+        - mountPath: /host/root
+          mountPropagation: HostToContainer
+          name: root
+          readOnly: true
+      tolerations:
+      - key: node-role.kubernetes.io/control-plane
+        effect: NoSchedule
+      volumes:
+      - hostPath:
+          path: /sys
+        name: sys
+      - hostPath:
+          path: /
+        name: root

--- a/kubernetes-controllers/paymentservice-deployment-bg.yaml
+++ b/kubernetes-controllers/paymentservice-deployment-bg.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: paymentservice
+  labels:
+    app: paymentservice
+spec:
+  replicas: 3
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 3
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: paymentservice
+  template:
+    metadata:
+      labels:
+        app: paymentservice
+    spec:
+      containers:
+      - name: server
+        image: anmcqueen/mcqueen_repo:paymentservice.v0.0.2
+        ports:
+        - containerPort: 50051
+        env:
+        - name: PORT
+          value: "50051"
+        - name: DISABLE_PROFILER
+          value: "1"

--- a/kubernetes-controllers/paymentservice-deployment-reverse.yaml
+++ b/kubernetes-controllers/paymentservice-deployment-reverse.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: paymentservice
+  labels:
+    app: paymentservice
+spec:
+  replicas: 3
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: paymentservice
+  template:
+    metadata:
+      labels:
+        app: paymentservice
+    spec:
+      containers:
+      - name: server
+        image: anmcqueen/mcqueen_repo:paymentservice.v0.0.2
+        ports:
+        - containerPort: 50051
+        env:
+        - name: PORT
+          value: "50051"
+        - name: DISABLE_PROFILER
+          value: "1"

--- a/kubernetes-controllers/paymentservice-deployment.yaml
+++ b/kubernetes-controllers/paymentservice-deployment.yaml
@@ -1,0 +1,26 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: paymentservice
+  labels:
+    app: paymentservice
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: paymentservice
+  template:
+    metadata:
+      labels:
+        app: paymentservice
+    spec:
+      containers:
+      - name: server
+        image: anmcqueen/mcqueen_repo:paymentservice.v0.0.2
+        ports:
+        - containerPort: 50051
+        env:
+        - name: PORT
+          value: "50051"
+        - name: DISABLE_PROFILER
+          value: "1"

--- a/kubernetes-controllers/paymentservice-replicaset.yaml
+++ b/kubernetes-controllers/paymentservice-replicaset.yaml
@@ -1,0 +1,26 @@
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  name: paymentservice
+  labels:
+    app: paymentservice
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: paymentservice
+  template:
+    metadata:
+      labels:
+        app: paymentservice
+    spec:
+      containers:
+      - name: server
+        image: anmcqueen/mcqueen_repo:paymentservice.v0.0.1
+        ports:
+        - containerPort: 50051
+        env:
+        - name: PORT
+          value: "50051"
+        - name: DISABLE_PROFILER
+          value: "1"

--- a/kubernetes-intro/README.md
+++ b/kubernetes-intro/README.md
@@ -1,0 +1,49 @@
+# Выполнено ДЗ № 1
+
+ - [x] Основное ДЗ
+ - [ ] Задание со *
+
+## В процессе сделано:
+ - Установлены docker, kubectl, minikube и аддон для k8s - Dashboard
+ - Проверена отказоустойчивость k8s путем удаления всех контейнеров в неймспейсе kube-system.
+**Ответ на задание** "Разберитесь почему все pod в namespace kube-system восстановились
+после удаления. Укажите причину в описании PR": 
+Поды в неймспейсе kube-system самостоятельно восстановились по трем причинам:
+1. Под coredns контролируется с помощью Deployment, который использует ReplicaSet. Посмотрев Deployment, видим заданное количество реплик = 1: 
+```
+$ kubectl edit deployment coredns -n kube-system
+...
+replicas: 1
+```
+...
+2. Под kube-proxy управляется при помощи DaemonSet. Таким образом, DaemonSet контролирует, что под kube-proxy всегда запущен на каждом узле кластера.
+3. Поды etcd, kube-apiserver, kube-controller-manager и kube-scheduler являются static Pods, поэтому kubelet следит, чтобы каждый из этих подов был всегда запущен. Манифесты этих подов описаны по пути /etc/kubernetes/manifests/:
+```
+$ minikube ssh
+Last login: Sun Mar 12 14:57:03 2023 from 192.168.49.1
+docker@minikube:~$ ls -lah /etc/kubernetes/manifests/
+total 28K
+drwxr-xr-x 1 root root 4.0K Mar 11 19:46 .
+drwxr-xr-x 1 root root 4.0K Mar 11 19:46 ..
+-rw------- 1 root root 2.5K Mar 11 19:46 etcd.yaml
+-rw------- 1 root root 4.0K Mar 11 19:46 kube-apiserver.yaml
+-rw------- 1 root root 3.4K Mar 11 19:46 kube-controller-manager.yaml
+-rw------- 1 root root 1.5K Mar 11 19:46 kube-scheduler.yaml
+```
+   - Создан веб-сервер на nginx и собран в docker-образ. Docker-образ запушен в Docker Hub
+   - Создан манифест web-pod.yaml и применен при помощи команды kubectl apply 
+   - Затем дополнила манифест web-pod.yaml описанием init-контейнера. Также описаны volumeMounts для контейнеров web и init и volumes в spec.
+   - Удален запущенный под, и применен обновленный манифест web-pod.yaml 
+   - Командой kubectl port-forward на локалхост проброшен порт 8000, в результате чего по ссылке http://localhost:8000/index.html открывается веб-страница.
+
+## Как запустить проект:
+ - В директории kubernetes-intro запустить команду:
+   `kubectl apply -f web-pod.yaml`
+
+## Как проверить работоспособность:
+ - Пробросить порт командой
+` kubectl port-forward --address 0.0.0.0 pod/web 8000:8000`
+ - Перейти на страницу: http://localhost:8000/index.html  
+
+## PR checklist:
+ - [x] Выставлен label с темой домашнего задания

--- a/kubernetes-intro/frontend-pod-healthy.yaml
+++ b/kubernetes-intro/frontend-pod-healthy.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  creationTimestamp: null
+  labels:
+    run: frontend
+  name: frontend
+spec:
+  containers:
+  - image: anmcqueen/mcqueen_repo:frontend
+    name: frontend
+    env:
+    - name: PRODUCT_CATALOG_SERVICE_ADDR
+      value: "productcatalogservice:3550"
+    - name: CURRENCY_SERVICE_ADDR
+      value: "currencyservice:7000"
+    - name: CART_SERVICE_ADDR
+      value: "cartservice:7070"
+    - name: RECOMMENDATION_SERVICE_ADDR
+      value: "recommendationservice:8080"
+    - name: SHIPPING_SERVICE_ADDR
+      value: "shippingservice:50051"
+    - name: CHECKOUT_SERVICE_ADDR
+      value: "checkoutservice:5050"
+    - name: AD_SERVICE_ADDR
+      value: "adservice:9555"
+    - name: ENABLE_PROFILER
+      value: "0"
+    resources: {}
+  dnsPolicy: ClusterFirst
+  restartPolicy: Never
+status: {}

--- a/kubernetes-intro/frontend-pod.yaml
+++ b/kubernetes-intro/frontend-pod.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  creationTimestamp: null
+  labels:
+    run: frontend
+  name: frontend
+spec:
+  containers: 
+  - image: anmcqueen/mcqueen_repo:frontend
+    name: frontend
+    resources: {}
+  dnsPolicy: ClusterFirst
+  restartPolicy: Never
+status: {}

--- a/kubernetes-intro/web-pod.yaml
+++ b/kubernetes-intro/web-pod.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Pod # Объект, который создаем
+metadata:
+  name: web # Название Pod
+  labels: # Метки в формате key: value
+    key: app
+spec: # Описание Pod
+  initContainers:
+    - name: init
+      image: busybox:1.31.0
+      command: ['sh', '-c', 'wget -O- https://tinyurl.com/otus-k8s-intro | sh']
+      volumeMounts:
+        - name: app
+          mountPath: /app
+  containers: # Описание контейнеров внутри Pod
+  - name: web # Название контейнера
+    image: anmcqueen/mcqueen_repo:hw # Образ из которого создается контейнер
+    volumeMounts:
+    - name: app
+      mountPath: /app
+  volumes:
+  - name: app
+    emptyDir: {}

--- a/kubernetes-intro/web/Dockerfile
+++ b/kubernetes-intro/web/Dockerfile
@@ -1,0 +1,12 @@
+FROM nginx:alpine
+LABEL maintainer="asetorn@yandex.ru"
+RUN mkdir /app && \
+    addgroup -g 1001 node && \
+    adduser -u 1001 -G node -s /bin/sh -D node && \
+    chown -R 1001 /app && \
+    chown -R 1001 /etc/nginx/conf.d/ && \
+    chown -R 1001 /var/cache/nginx/
+WORKDIR /app
+ADD nginx.conf /etc/nginx/nginx.conf
+EXPOSE 8000
+USER 1001

--- a/kubernetes-intro/web/nginx.conf
+++ b/kubernetes-intro/web/nginx.conf
@@ -1,0 +1,72 @@
+user www-data;
+worker_processes auto;
+pid /tmp/nginx.pid;
+include /etc/nginx/modules-enabled/*.conf;
+
+events {
+	worker_connections 768;
+	# multi_accept on;
+}
+
+http {
+
+	##
+	# Basic Settings
+	##
+
+	sendfile on;
+	tcp_nopush on;
+	types_hash_max_size 2048;
+	server_tokens off;
+
+	# server_names_hash_bucket_size 64;
+	# server_name_in_redirect off;
+
+	include /etc/nginx/mime.types;
+	default_type application/octet-stream;
+
+	##
+	# SSL Settings
+	##
+
+	ssl_protocols TLSv1 TLSv1.1 TLSv1.2 TLSv1.3; # Dropping SSLv3, ref: POODLE
+	ssl_prefer_server_ciphers on;
+
+	
+	
+	##
+	# Logging Settings
+	##
+
+	access_log /var/log/nginx/access.log;
+	error_log /var/log/nginx/error.log;
+
+	##
+	# Gzip Settings
+	##
+
+	gzip on;
+
+	gzip_vary on;
+	# gzip_proxied any;
+	# gzip_comp_level 6;
+	# gzip_buffers 16 8k;
+	# gzip_http_version 1.1;
+	# gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
+
+	##
+	# Virtual Host Configs
+	##
+
+	include /etc/nginx/conf.d/*.conf;
+	include /etc/nginx/sites-enabled/*;
+
+ 	server {
+ 		listen 8000;
+		server_name localhost;
+		root /app;
+		
+		location / {
+		}
+ 	}
+}


### PR DESCRIPTION
# Выполнено ДЗ № 2

 - [x] Основное ДЗ
 - [x] Задание со *

## В процессе сделано:
 - Ответ на вопрос: Почему обновление ReplicaSet не повлекло обновление запущенных pod?
В ReplicaSet не предусмотрено использование rolling update, поэтому обновления подов не произошло.
 - Создан ReplicaSet сервиса frontend. Изменено количество реплик до 3 двумя способами: командой kubectl scale replicaset, а затем редактированием манифеста. 
 - Собрана новая версия микросервиса frontend, после чего эта версия была применена в манифесте ReplicaSet. После применения обновленного манифеста выяснила, что ReplicaSet не производит обновления текущих работающих подов. 
 - Собрано два image микросервиса paymentservice. Созданы манифесты ReplicaSet и Deployment для paymentservice. 
 - Выяснила, что при применении обновленного Deployment применяется стратегия обновления Rolling Update, которая заменяет поды со старой версией на поды с новой версией. 
 - Написано два манифеста Deployment с реализацией сценариев развертывания blue-green и Rolling Update
 - Для микросервиса frontend создан Deployment с readinessProbe. Узнала, что после применения обновленного манифеста Deployment не будет пытаться продолжить обновление, пока readinessProbe для нового пода не станет успешной.
 - Создан и применен манифест node-exporter-daemonset.yaml для развертывания DaemonSet с Node Exporter. На локалхост проброшен порт 9100 из пода node-exporter, после чего по url localhost:9100/metrics стали доступны метрики. 
 - DaemonSet node-exporter-daemonset.yaml модернизирован таким образом, чтобы Node Exporter был развернут не только на worker, так и на master (control-plane) ноде.

## Как запустить проект:
```
 - kubectl apply -f node-exporter-daemonset.yaml 
 - kubectl port-forward node-exporter-*** 9100:9100
```

## Как проверить работоспособность:
 - Перейти по ссылке localhost:9100/metrics 

## PR checklist:
 - [x] Выставлен label с темой домашнего задания
